### PR TITLE
Provide ability to run only package tests:

### DIFF
--- a/commands/test.js
+++ b/commands/test.js
@@ -24,6 +24,10 @@ exports.builder = {
   release: {
     description: 'Test using release assets',
     default: false
+  },
+  packages: {
+    description: 'Only run the package tests',
+    default: false
   }
 };
 
@@ -42,10 +46,16 @@ exports.getMochaArgs = (argv) => {
     args.push.apply(args, ['--invert', '--grep', 'spectron']);
   } else if (argv.functional) {
     args.push.apply(args, ['--grep', 'spectron']);
+  } else if (argv.packages) {
+    args.push.apply(args, ['--recursive']);
   }
 
   if (process.env.EVERGREEN) {
     args.push.apply(args, ['--reporter', 'mocha-evergreen-reporter']);
+  }
+
+  if (argv.packages) {
+    args.push.apply(args, ['./src/internal-packages']);
   }
 
   const omitKeys = _.flatten([

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -55,18 +55,34 @@ describe('hadron-build', () => {
 
   describe('::test', () => {
     describe('::getMochaArgs', () => {
-      it('should allow pass through of mocha cli options', () => {
-        var argv = {
-          _: [],
-          $0: 'hadron-build',
-          help: false,
-          recursive: true,
-          grep: '#spectron'
-        };
+      context('when the arguments are default', () => {
+        it('should allow pass through of mocha cli options', () => {
+          var argv = {
+            _: [],
+            $0: 'hadron-build',
+            help: false,
+            recursive: true,
+            grep: '#spectron'
+          };
 
-        expect(commands.test.getMochaArgs(argv)).to.deep.equal([
-          '--recursive', '--grep', '#spectron'
-        ]);
+          expect(commands.test.getMochaArgs(argv)).to.deep.equal([
+            '--recursive', '--grep', '#spectron'
+          ]);
+        });
+      });
+
+      context('when executing package tests', () => {
+        it('adds the recursive options and defaults to test internal-packages', () => {
+          var argv = {
+            _: [],
+            $0: 'hadron-build',
+            packages: true
+          };
+
+          expect(commands.test.getMochaArgs(argv)).to.deep.equal([
+            '--recursive', './src/internal-packages'
+          ]);
+        });
       });
     });
 


### PR DESCRIPTION
Can be run now with --packages passed through. For example from Compass:

```bash
  npm test -- --packages
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/hadron-build/8)
<!-- Reviewable:end -->
