### PR TITLE
remove assumption of channel names (namely `beta`)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -100,19 +100,18 @@ exports.get = (cli, callback) => {
    * and various `electron-installer-*` modules.
    */
   let channel = 'stable';
-  if (cli.argv.version.indexOf('-beta') > -1) {
-    channel = 'beta';
-  } else if (cli.argv.version.indexOf('-dev') > -1) {
-    channel = 'dev';
+  // extract channel from version string, e.g. `beta` for `1.3.5-beta.1`
+  const mtch = cli.argv.version.match(/-([a-z]+)(\.\d+)?$/);
+  if (mtch) {
+    channel = mtch[1];
   }
 
   let PRODUCT_NAME = cli.argv.product_name;
   assert(cli.argv.product_name);
 
-  if (channel === 'beta') {
-    PRODUCT_NAME += ' Beta';
-  } else if (channel === 'dev') {
-    PRODUCT_NAME += ' Dev';
+  if (channel !== 'stable') {
+    // add channel suffix to product name, e.g. "MongoDB Compass Beta"
+    PRODUCT_NAME += ' ' + _.capitalize(channel);
   }
 
   /**
@@ -197,8 +196,9 @@ exports.get = (cli, callback) => {
     CONFIG.windows_zip_label = CONFIG.windows_zip_filename = `${CONFIG.productName}-windows.zip`;
 
     let NUGET_VERSION = CONFIG.version;
-    if (CONFIG.channel === 'beta') {
-      NUGET_VERSION = CONFIG.version.replace(/-beta\.(\d+)/, '-beta$1');
+    if (CONFIG.channel !== 'master') {
+      // remove `.` from version tags for NUGET version
+      NUGET_VERSION = CONFIG.version.replace(new RegExp(`-${channel}\\.(\\d+)`), `-${channel}$1`);
     }
     const NUGET_NAME = CONFIG.productNameRealTitleCase;
     CONFIG.windows_nupkg_full_label = CONFIG.windows_nupkg_full_filename = `${NUGET_NAME}-${NUGET_VERSION}-full.nupkg`;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -95,6 +95,29 @@ describe('hadron-build::config', () => {
       });
     });
   });
+  describe('::custom channel', () => {
+    let res;
+    before( () => {
+      res = getConfig({
+        version: '1.2.0-custom.5',
+        name: 'hadron',
+        product_name: 'Hadron',
+        platform: 'win32',
+        author: 'MongoDB Inc'
+      });
+    });
+    it('should append the channel name to the product name', () => {
+      expect(res.productName).to.equal('Hadron Custom');
+      let versionString = res.packagerOptions['version-string'];
+      expect(versionString.ProductName).to.equal('Hadron Custom');
+    });
+    it('should have the correct asset filenames', () => {
+      expect(res.windows_msi_filename).to.equal('Hadron CustomSetup.msi');
+      expect(res.windows_setup_filename).to.equal('Hadron CustomSetup.exe');
+      expect(res.windows_zip_filename).to.equal('Hadron Custom-windows.zip');
+      expect(res.windows_nupkg_full_filename).to.equal('Hadron-1.2.0-custom5-full.nupkg');
+    });
+  });
   describe('::beta channel', () => {
     let res;
     before( () => {


### PR DESCRIPTION
Currently, hadron-build assumes that channel can only be one of `stable`, `dev`, `beta`. We can relax this assumption and only differ between `stable` and all other branches, e.g. `world`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/hadron-build/10)
<!-- Reviewable:end -->
