### PR TITLE
INT-1491: :bug: :checkered_flag: nuget name should include channel

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -153,8 +153,6 @@ exports.get = (cli, callback) => {
   CONFIG.channel = channel;
   CONFIG.productName = PRODUCT_NAME;
   CONFIG.productNameTitleCase = CONFIG.productName.replace(/ /g, '');
-  CONFIG.productNameReal = cli.argv.product_name;
-  CONFIG.productNameRealTitleCase = CONFIG.productNameReal.replace(/ /g, '');
   CONFIG.dir = PROJECT_ROOT;
 
   CONFIG.src = function() {
@@ -200,7 +198,7 @@ exports.get = (cli, callback) => {
       // remove `.` from version tags for NUGET version
       NUGET_VERSION = CONFIG.version.replace(new RegExp(`-${channel}\\.(\\d+)`), `-${channel}$1`);
     }
-    const NUGET_NAME = CONFIG.productNameRealTitleCase;
+    const NUGET_NAME = CONFIG.productNameTitleCase;
     CONFIG.windows_nupkg_full_label = CONFIG.windows_nupkg_full_filename = `${NUGET_NAME}-${NUGET_VERSION}-full.nupkg`;
 
     CONFIG.assets = [

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -115,7 +115,7 @@ describe('hadron-build::config', () => {
       expect(res.windows_msi_filename).to.equal('Hadron CustomSetup.msi');
       expect(res.windows_setup_filename).to.equal('Hadron CustomSetup.exe');
       expect(res.windows_zip_filename).to.equal('Hadron Custom-windows.zip');
-      expect(res.windows_nupkg_full_filename).to.equal('Hadron-1.2.0-custom5-full.nupkg');
+      expect(res.windows_nupkg_full_filename).to.equal('HadronCustom-1.2.0-custom5-full.nupkg');
     });
   });
   describe('::beta channel', () => {
@@ -140,7 +140,7 @@ describe('hadron-build::config', () => {
       expect(res.windows_msi_filename).to.equal('Hadron BetaSetup.msi');
       expect(res.windows_setup_filename).to.equal('Hadron BetaSetup.exe');
       expect(res.windows_zip_filename).to.equal('Hadron Beta-windows.zip');
-      expect(res.windows_nupkg_full_filename).to.equal('Hadron-1.2.0-beta1-full.nupkg');
+      expect(res.windows_nupkg_full_filename).to.equal('HadronBeta-1.2.0-beta1-full.nupkg');
     });
 
     it('should have the platform specific installer options', () => {


### PR DESCRIPTION
This way beta and stable will have their own install paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb-js/hadron-build/11)
<!-- Reviewable:end -->
