### PR TITLE
COMPASS-179 new background

### DIFF
--- a/commands/ui.js
+++ b/commands/ui.js
@@ -45,7 +45,7 @@ exports.builder = {
 
 exports.handler = (argv) => {
   cli.argv = argv;
-  exports.task(argv).catch(abortIfError);
+  exports.tasks(argv).catch(abortIfError);
 };
 
 exports.tasks = (argv) => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -367,8 +367,8 @@ exports.get = (cli, callback) => {
          * Show a shortcut on the right to `Applications` folder.
          */
         {
-          x: 450,
-          y: 344,
+          x: 322,
+          y: 243,
           type: 'link',
           path: '/Applications'
         },
@@ -376,8 +376,8 @@ exports.get = (cli, callback) => {
          * Show a shortcut on the left for the application icon.
          */
         {
-          x: 192,
-          y: 344,
+          x: 93,
+          y: 243,
           type: 'file',
           path: OSX_DOT_APP
         }


### PR DESCRIPTION
Adjust positions of Icons for new background DMG image. 

Note: In order not to affect older builds, we should bump the major version here to avoid accidentally rolling this change forward, or we need to backport the new DMG backgrounds to at least 1.4.0 (we probably won't be building 1.3.x versions anymore).

Ideally, this would not be hard-coded here though but Compass would set it in its package.json `build` key.