### PR TITLE
Enable dedupe'ing electron-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "electron-mocha": "^3.1.1",
     "electron-osx-sign": "^0.4.1",
     "electron-packager": "^8.0.0",
-    "electron-prebuilt": "^1.4.12",
+    "electron-prebuilt": "^1.2.8",
     "electron-winstaller": "^2.3.3",
     "flatnest": "^1.0.0",
     "fs-extra": "^1.0.0",


### PR DESCRIPTION
If an app has specifically defined an electron-prebuilt version such as
`1.2.8`, having hadron-build require `^1.4.12` would cause unexpected
behavior. The app in this case would be compiling native add-on’s
targeting the abi for `1.2.8` and they would suddenly start to fail as
`hadron-build develop` would use `1.4.12` which is abi incompatible.