### PR TITLE
Make platform specific dependencies optional

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -407,7 +407,7 @@ exports.get = (cli, callback) => {
               icon: LINUX_ICON,
               name: CONFIG.slug,
               version: [target.semver.major, target.semver.minor, target.semver.patch].join('.'),
-              revision: target.semver.prerelease.join('.')
+              revision: target.semver.prerelease.join('.') || '1'
             };
             cli.debug('calling electron-installer-redhat with options', rpmOptions);
             const createRpm = require('electron-installer-redhat');

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,11 +6,6 @@ const _ = require('lodash');
 const async = require('async');
 const which = require('which');
 const tarPack = require('tar-pack').pack;
-const createDMG = require('electron-installer-dmg');
-const codesign = require('electron-installer-codesign');
-const electronWinstaller = require('electron-winstaller');
-const createDeb = require('electron-installer-debian');
-const createRpm = require('electron-installer-redhat');
 const Target = require('./target');
 
 exports.get = (cli, callback) => {
@@ -209,6 +204,7 @@ exports.get = (cli, callback) => {
     };
 
     CONFIG.createInstaller = (done) => {
+      const electronWinstaller = require('electron-winstaller');
       electronWinstaller.createWindowsInstaller(CONFIG.installerOptions)
         .then(function(res) {
           cli.debug('Successfully created installers', res);
@@ -219,6 +215,9 @@ exports.get = (cli, callback) => {
     /**
      * ## OS X Configuration
      */
+    const createDMG = require('electron-installer-dmg');
+    const codesign = require('electron-installer-codesign');
+
     const OSX_APPNAME = CONFIG.productName;
     const OSX_OUT_X64 = CONFIG.dest(`${OSX_APPNAME}-darwin-x64`);
     const OSX_DOT_APP = path.join(OSX_OUT_X64, `${OSX_APPNAME}.app`);
@@ -410,6 +409,8 @@ exports.get = (cli, callback) => {
               version: [target.semver.major, target.semver.minor, target.semver.patch].join('.'),
               revision: target.semver.prerelease.join('.')
             };
+            cli.debug('calling electron-installer-redhat with options', rpmOptions);
+            const createRpm = require('electron-installer-redhat');
             createRpm(rpmOptions, cb);
           });
         },
@@ -433,6 +434,7 @@ exports.get = (cli, callback) => {
               version: CONFIG.version.replace(/\./g, '~')
             };
             cli.debug('calling electron-installer-debian with options', debOptions);
+            const createDeb = require('electron-installer-debian');
             createDeb(debOptions, cb);
           });
         },

--- a/package.json
+++ b/package.json
@@ -25,18 +25,12 @@
     "cli-table": "^0.3.1",
     "debug": "^2.2.0",
     "del": "^2.0.2",
-    "electron-installer-codesign": "^0.3.0",
-    "electron-installer-debian": "^0.4.0",
-    "electron-installer-dmg": "^0.1.1",
-    "electron-installer-redhat": "^0.3.0",
     "electron-installer-run": "^0.1.2",
     "electron-installer-zip": "^0.1.2",
     "electron-license": "^0.2.0",
     "electron-mocha": "^3.1.1",
-    "electron-osx-sign": "^0.4.1",
     "electron-packager": "^8.0.0",
     "electron-prebuilt": "^1.2.8",
-    "electron-winstaller": "^2.3.3",
     "flatnest": "^1.0.0",
     "fs-extra": "^1.0.0",
     "github": "^6.0.4",
@@ -66,6 +60,14 @@
     "mongodb-js-precommit": "^0.2.9",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
+  },
+  "optionalDependencies" : {
+    "electron-installer-codesign": "^0.3.0",
+    "electron-installer-debian": "^0.4.0",
+    "electron-installer-dmg": "^0.1.1",
+    "electron-installer-redhat": "^0.3.0",
+    "electron-osx-sign": "^0.4.1",
+    "electron-winstaller": "^2.3.3"
   },
   "license": "Apache-2.0"
 }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -100,15 +100,15 @@ describe('hadron-build::config', () => {
     const c = getConfig(linux);
     const assetNames = _.map(c.assets, 'name');
     it('should produce a tarball asset', () => {
-      expect(assetNames).to.contain('hadron-app-1.2.0-linux-x64.tar.gz');
+      expect(assetNames).to.contain(`hadron-app-1.2.0-linux-${c.arch}.tar.gz`);
     });
 
     it('should produce a debian package asset', () => {
-      expect(assetNames).to.contain('hadron-app-1.2.0-linux-x64.deb');
+      expect(assetNames).to.contain(`hadron-app-1.2.0-linux-${c.arch}.deb`);
     });
 
     it('should produce a redhat package manager asset', () => {
-      expect(assetNames).to.include('hadron-app.1.2.0.linux.x64.rpm');
+      expect(assetNames).to.include(`hadron-app.1.2.0.linux.${c.arch}.rpm`);
     });
   });
 

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -23,56 +23,60 @@ const withDefaults = (argv) => {
   return CONFIG;
 };
 
-describe('hadron-build::release', function() {
-  this.timeout(300000);
-  var CONFIG = {};
+if (process.platform === 'win32') {
+  console.warn('Functional tests on appveyor too slow. Skipping.');
+} else {
+  describe('hadron-build::release', function() {
+    this.timeout(300000);
+    var CONFIG = null;
 
-  before( (done) => {
-    if (process.platform === 'windows') {
-      return done();
-    }
-
-    fs.remove(path.join(__dirname, 'fixtures', 'hadron-app', 'dist'), (_err) => {
-      if (_err) {
-        return done(_err);
-      }
-      commands.release.run(withDefaults({ product_name: 'Hadron App' }), (err, _config) => {
-        if (err) {
-          return done(err);
+    before(function(done) {
+      fs.remove(path.join(__dirname, 'fixtures', 'hadron-app', 'dist'), (_err) => {
+        if (_err) {
+          return done(_err);
         }
-        CONFIG = _config;
-        done();
-      });
-    });
-  });
-
-  it('should symlink `Electron` to the app binary on OS X', function(done) {
-    if (CONFIG.platform !== 'darwin') {
-      return done();
-    }
-
-    const bin = path.join(CONFIG.appPath, 'Contents', 'MacOS', 'Electron');
-    fs.exists(bin, function(exists) {
-      assert(exists, `Expected ${bin} to exist`);
-      done();
-    });
-  });
-
-  /**
-   * TODO (imlucas) Compare from `CONFIG.icon` to
-   * `path.join(CONFIG.resource, 'electron.icns')` (platform specific).
-   * Should have matching md5 of contents.
-   */
-  it('should have the correct application icon');
-
-  it('should have all assets specified in the manifest', () => {
-    CONFIG.assets.map(function(asset) {
-      it(`should have created \`${asset.name}\``, (done) => {
-        fs.exists(asset.path, function(exists) {
-          assert(exists, `Asset file should exist at ${asset.path}`);
+        commands.release.run(withDefaults({
+          name: 'hadron-app',
+          version: '1.2.0',
+          product_name: 'Hadron App'
+        }), (err, _config) => {
+          if (err) {
+            return done(err);
+          }
+          CONFIG = _config;
           done();
         });
       });
     });
+
+    it('should symlink `Electron` to the app binary on OS X', function(done) {
+      if (CONFIG.platform !== 'darwin') {
+        return this.skip();
+      }
+
+      const bin = path.join(CONFIG.appPath, 'Contents', 'MacOS', 'Electron');
+      fs.exists(bin, function(exists) {
+        assert(exists, `Expected ${bin} to exist`);
+        done();
+      });
+    });
+
+    /**
+     * TODO (imlucas) Compare from `CONFIG.icon` to
+     * `path.join(CONFIG.resource, 'electron.icns')` (platform specific).
+     * Should have matching md5 of contents.
+     */
+    it('should have the correct application icon');
+
+    it('should have all assets specified in the manifest', () => {
+      CONFIG.assets.map(function(asset) {
+        it(`should have created \`${asset.name}\``, (done) => {
+          fs.exists(asset.path, function(exists) {
+            assert(exists, `Asset file should exist at ${asset.path}`);
+            done();
+          });
+        });
+      });
+    });
   });
-});
+}

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -24,7 +24,7 @@ const withDefaults = (argv) => {
 };
 
 if (process.platform === 'win32') {
-  console.warn('Functional tests on appveyor too slow. Skipping.');
+  // Functional tests on appveyor too slow. Skipping.
 } else {
   describe('hadron-build::release', function() {
     this.timeout(300000);


### PR DESCRIPTION
Our upstreams could potentially use npm’s platform requirement (e.g.
`electron-installer-debian` just won’t install on windows). Moving them
to `optionalDependencies` and inlining the `require()` calls for them
inline means we can be graceful and test thoroughly on any platform.