### PR TITLE
COMPASS-546: Get Ubuntu .deb installer working, get Redhat .rpm closer to working

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -94,7 +94,7 @@ class Target {
   src(...args) {
     if (_.first(args) === undefined) return undefined;
     args.unshift(this.dir);
-    return path.join.apply(path, args);
+    return path.join(...args);
   }
 
   /**
@@ -104,7 +104,7 @@ class Target {
   dest(...args) {
     if (_.first(args) === undefined) return undefined;
     args.unshift(this.out);
-    return path.join.apply(path, args);
+    return path.join(...args);
   }
 
   /**

--- a/lib/target.js
+++ b/lib/target.js
@@ -402,10 +402,11 @@ class Target {
          * @see https://github.com/unindented/electron-installer-redhat#options
          */
         const createRpm = require('electron-installer-redhat');
+        const installerArch = this.arch === 'x64' ? 'x86_64' : undefined;
         createRpm({
           src: LINUX_OUT_X64,
           dest: this.out,
-          arch: this.arch,
+          arch: installerArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
           version: [this.semver.major, this.semver.minor, this.semver.patch].join('.'),
@@ -426,10 +427,11 @@ class Target {
          * @see https://github.com/unindented/electron-installer-debian#options
          */
         const createDeb = require('electron-installer-debian');
+        const installerArch = this.arch === 'x64' ? 'amd64' : undefined;
         createDeb({
           src: LINUX_OUT_X64,
           dest: this.out,
-          arch: this.arch,
+          arch: installerArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
           version: this.version.replace(/\./g, '~')

--- a/lib/target.js
+++ b/lib/target.js
@@ -434,7 +434,7 @@ class Target {
           arch: installerArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
-          version: this.version.replace(/\./g, '~')
+          version: this.version
         }, cb);
       });
     };


### PR DESCRIPTION
RPM BEFORE
<img width="1107" alt="example of the x64 rpm failing requires x86_64" src="https://cloud.githubusercontent.com/assets/1217010/21346788/028bd70a-c6fa-11e6-8faf-7d1218e66cd3.png">

RPM AFTER (Installs but creates a broken symlink. Manually finding the executable and then starting Compass appears to fail with the same libXss.so missing dependency as I saw with the [electron-builder](https://github.com/electron-userland/electron-builder) AppImage)
![improves the rhel experience too - gets to same missing library message as electron-builder](https://cloud.githubusercontent.com/assets/1217010/21346798/0a397070-c6fa-11e6-86ef-384b0fcdbaed.png)

UBUNTU BEFORE
![wrong architecture x64 instead of amd64](https://cloud.githubusercontent.com/assets/1217010/21346806/162400da-c6fa-11e6-9ddd-02dfb2090f64.png)

UBUNTU AFTER (same broken symlink issue as the `.rpm`)
<img width="1201" alt="ubuntu installs after this change" src="https://cloud.githubusercontent.com/assets/1217010/21347511/09ba36fe-c6fd-11e6-8a9e-eb85857556ff.png">
<img width="1439" alt="scratch earlier advice ubuntu works with deb installer at least to the same vm" src="https://cloud.githubusercontent.com/assets/1217010/21347614/83457aa6-c6fd-11e6-8284-f82e6a3cd599.png">
