### PR TITLE
COMPASS-546 & 547: Configure Linux metadata 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
         },
         "linux": {
           "icon": "resources/linux/<your-project-id>.png",
-          "debianConfig": {
+          "debian_config": {
             "section": "Databases",
             "depends": [
               "python"
@@ -36,7 +36,7 @@
               "libgnome-keyring0"
             ]
           },
-          "redhatConfig": {
+          "redhat_config": {
             "category": "Applications/Databases",
             "requires": [
               "libXScrnSaver(x86-64)"

--- a/README.md
+++ b/README.md
@@ -91,12 +91,12 @@
 
 #### build.linux.icon
 
-#### build.linux.debian
+#### build.linux.debian_config
 
 Additional options to be passed to 
 https://github.com/unindented/electron-installer-debian#options
 
-#### build.linux.redhat
+#### build.linux.redhat_config
 
 Additional options to be passed to
 https://github.com/unindented/electron-installer-redhat#options

--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@
           "app_category_type": "public.app-category.productivity"
         },
         "linux": {
-          "icon": "resources/linux/<your-project-id>.png"
+          "icon": "resources/linux/<your-project-id>.png",
+          "debianConfig": {
+            "section": "Databases",
+            "depends": [
+              "python"
+            ],
+            "suggests": [
+              "libgnome-keyring0"
+            ]
+          },
+          "redhatConfig": {
+            "category": "Applications/Databases",
+            "requires": [
+              "libXScrnSaver(x86-64)"
+            ]
+          }
         }
       },
       "endpoint": "<hadron-endpoint-server-url>"
@@ -75,6 +90,16 @@
 ### build.linux
 
 #### build.linux.icon
+
+#### build.linux.debian
+
+Additional options to be passed to 
+https://github.com/unindented/electron-installer-debian#options
+
+#### build.linux.redhat
+
+Additional options to be passed to
+https://github.com/unindented/electron-installer-redhat#options
 
 ## CLI Usage
 

--- a/lib/target.js
+++ b/lib/target.js
@@ -102,7 +102,7 @@ class Target {
   src(...args) {
     if (_.first(args) === undefined) return undefined;
     args.unshift(this.dir);
-    return path.join.apply(path, args);
+    return path.join(...args);
   }
 
   /**
@@ -112,7 +112,7 @@ class Target {
   dest(...args) {
     if (_.first(args) === undefined) return undefined;
     args.unshift(this.out);
-    return path.join.apply(path, args);
+    return path.join(...args);
   }
 
   write(filename, contents) {

--- a/lib/target.js
+++ b/lib/target.js
@@ -418,6 +418,37 @@ class Target {
         path: LINUX_OUT_ZIP
       }
     ];
+    const defaultLinuxConfig = {
+      src: this.appPath,
+      dest: this.out,
+      icon: this.src(platformSettings.icon),
+      name: this.slug,
+      bin: this.productName
+    };
+    const defaultDebianConfig = {
+      arch: debianArch,
+      version: debianVersion
+    };
+    const debianConfig = Object.assign(
+      {},
+      defaultLinuxConfig,
+      defaultDebianConfig,
+      platformSettings.debianConfig
+    );
+    this.debian_config = debianConfig;
+
+    const defaultRedHatConfig = {
+      arch: rhelArch,
+      version: rhelVersion,
+      revision: rhelRevision
+    };
+    const redhatConfig = Object.assign(
+      {},
+      defaultLinuxConfig,
+      defaultRedHatConfig,
+      platformSettings.redhatConfig
+    );
+    this.redhat_config = redhatConfig;
 
     const which = require('which');
     const createRpmInstaller = cb => {
@@ -433,22 +464,7 @@ class Target {
          * @see https://github.com/unindented/electron-installer-redhat#options
          */
         const createRpm = require('electron-installer-redhat');
-        const defaultRedHatConfig = {
-          src: this.appPath,
-          dest: this.out,
-          arch: rhelArch,
-          icon: this.src(platformSettings.icon),
-          name: this.slug,
-          version: rhelVersion,
-          revision: rhelRevision,
-          bin: this.productName
-        };
-        const redHatConfig = Object.assign(
-          {},
-          defaultRedHatConfig,
-          platformSettings.redhatConfig
-        );
-        createRpm(redHatConfig, cb);
+        createRpm(redhatConfig, cb);
       });
     };
 
@@ -465,20 +481,6 @@ class Target {
          * @see https://github.com/unindented/electron-installer-debian#options
          */
         const createDeb = require('electron-installer-debian');
-        const defaultDebianConfig = {
-          src: this.appPath,
-          dest: this.out,
-          arch: debianArch,
-          icon: this.src(platformSettings.icon),
-          name: this.slug,
-          version: debianVersion,
-          bin: this.productName
-        };
-        const debianConfig = Object.assign(
-          {},
-          defaultDebianConfig,
-          platformSettings.debianConfig
-        );
         createDeb(debianConfig, cb);
       });
     };

--- a/lib/target.js
+++ b/lib/target.js
@@ -425,25 +425,30 @@ class Target {
         if (err) {
           /* eslint no-console: 0 */
           console.warn('Your environment is not configured correctly to build ' +
-          'rpm packages. Please see https://git.io/v1iz7');
+          '.rpm packages. Please see https://git.io/v1iz7');
           return cb();
         }
         /**
-         * TODO (imlucas) Use pretty Redhat metadata and options.
+         * Let applications override our default Red Hat metadata and options.
          * @see https://github.com/unindented/electron-installer-redhat#options
          */
         const createRpm = require('electron-installer-redhat');
-        createRpm({
+        const defaultRedHatConfig = {
           src: this.appPath,
           dest: this.out,
           arch: rhelArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
-          requires: platformSettings.requires,
           version: rhelVersion,
           revision: rhelRevision,
           bin: this.productName
-        }, cb);
+        };
+        const redHatConfig = Object.assign(
+          {},
+          defaultRedHatConfig,
+          platformSettings.redhatConfig
+        );
+        createRpm(redHatConfig, cb);
       });
     };
 
@@ -452,29 +457,29 @@ class Target {
         if (err) {
           /* eslint no-console: 0 */
           console.warn('Your environment is not configured correctly to build ' +
-          'debian packages. Please see https://git.io/v1iRV');
+          '.deb packages. Please see https://git.io/v1iRV');
           return cb();
         }
         /**
-         * TODO (imlucas) Use pretty debian metadata and options.
+         * Let applications override our default Debian metadata and options.
          * @see https://github.com/unindented/electron-installer-debian#options
          */
         const createDeb = require('electron-installer-debian');
-        createDeb({
+        const defaultDebianConfig = {
           src: this.appPath,
           dest: this.out,
           arch: debianArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
-          depends: platformSettings.depends,
-          recommends: platformSettings.recommends,
-          suggests: platformSettings.suggests,
-          enhances: platformSettings.enhances,
-          preDepends: platformSettings.preDepends,
-          section: platformSettings.section,
           version: debianVersion,
           bin: this.productName
-        }, cb);
+        };
+        const debianConfig = Object.assign(
+          {},
+          defaultDebianConfig,
+          platformSettings.debianConfig
+        );
+        createDeb(debianConfig, cb);
       });
     };
 

--- a/lib/target.js
+++ b/lib/target.js
@@ -439,6 +439,7 @@ class Target {
           arch: rhelArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
+          requires: platformSettings.requires,
           version: rhelVersion,
           revision: rhelRevision,
           bin: this.productName

--- a/lib/target.js
+++ b/lib/target.js
@@ -465,6 +465,7 @@ class Target {
           arch: debianArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
+          section: platformSettings.section,
           version: debianVersion,
           bin: this.productName
         }, cb);

--- a/lib/target.js
+++ b/lib/target.js
@@ -465,6 +465,11 @@ class Target {
           arch: debianArch,
           icon: this.src(platformSettings.icon),
           name: this.slug,
+          depends: platformSettings.depends,
+          recommends: platformSettings.recommends,
+          suggests: platformSettings.suggests,
+          enhances: platformSettings.enhances,
+          preDepends: platformSettings.preDepends,
           section: platformSettings.section,
           version: debianVersion,
           bin: this.productName

--- a/lib/target.js
+++ b/lib/target.js
@@ -433,7 +433,7 @@ class Target {
       {},
       defaultLinuxConfig,
       defaultDebianConfig,
-      platformSettings.debianConfig
+      platformSettings.debian_config
     );
     this.debian_config = debianConfig;
 
@@ -446,7 +446,7 @@ class Target {
       {},
       defaultLinuxConfig,
       defaultRedHatConfig,
-      platformSettings.redhatConfig
+      platformSettings.redhat_config
     );
     this.redhat_config = redhatConfig;
 

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -77,6 +77,7 @@ describe('hadron-build::config', () => {
       name: 'hadron-app',
       version: '1.2.0',
       product_name: 'Hadron',
+      arch: 'x64',
       platform: 'linux'
     };
     const appDir = path.join(process.cwd(), 'test', 'fixtures', 'hadron-app');

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -83,9 +83,9 @@ describe('hadron-build::config', () => {
     const expectLinuxConfig = {
       'bin': 'Hadron',
       'dest': path.join(appDir, 'dist'),
-      'icon':  path.join(appDir, 'resources', 'linux', 'Icon.png'),
+      'icon': path.join(appDir, 'resources', 'linux', 'Icon.png'),
       'name': 'hadron-app',
-      'src':  path.join(appDir, 'dist', 'Hadron-linux-x64')
+      'src': path.join(appDir, 'dist', 'Hadron-linux-x64')
     };
     const expectDebianConfig = Object.assign(
       {},

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -107,7 +107,9 @@ describe('hadron-build::config', () => {
       expectLinuxConfig,
       {
         'arch': 'x86_64',
-        'category': 'Applications/Databases',
+        'categories': [
+          'Development'
+        ],
         'requires': [
           'libXScrnSaver(x86-64)'
         ],

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const chai = require('chai');
 const getConfig = require('./helpers').getConfig;
 const expect = chai.expect;
+const path = require('path');
 
 describe('hadron-build::config', () => {
   describe('Release channel support', () => {
@@ -78,6 +79,42 @@ describe('hadron-build::config', () => {
       product_name: 'Hadron',
       platform: 'linux'
     };
+    const appDir = path.join(process.cwd(), 'test', 'fixtures', 'hadron-app');
+    const expectLinuxConfig = {
+      'bin': 'Hadron',
+      'dest': path.join(appDir, 'dist'),
+      'icon':  path.join(appDir, 'resources', 'linux', 'Icon.png'),
+      'name': 'hadron-app',
+      'src':  path.join(appDir, 'dist', 'Hadron-linux-x64')
+    };
+    const expectDebianConfig = Object.assign(
+      {},
+      expectLinuxConfig,
+      {
+        'arch': 'amd64',
+        'section': 'Databases',
+        'depends': [
+          'python'
+        ],
+        'suggests': [
+          'libgnome-keyring0'
+        ],
+        'version': '1.2.0'
+      }
+    );
+    const expectRedHatConfig = Object.assign(
+      {},
+      expectLinuxConfig,
+      {
+        'arch': 'x86_64',
+        'category': 'Applications/Databases',
+        'requires': [
+          'libXScrnSaver(x86-64)'
+        ],
+        'revision': '1',
+        'version': '1.2.0'
+      }
+    );
 
     const c = getConfig(linux);
     const assetNames = _.map(c.assets, 'name');
@@ -89,8 +126,18 @@ describe('hadron-build::config', () => {
       expect(assetNames).to.contain(c.linux_deb_filename);
     });
 
+    // Would be nicer to test these independently without the fixture,
+    // but not sure how to mock files
+    it('should allow configuring debian_config options', () => {
+      expect(c.debian_config).to.deep.equal(expectDebianConfig);
+    });
+
     it('should produce a redhat package manager asset', () => {
       expect(assetNames).to.include(c.linux_rpm_filename);
+    });
+
+    it('should allow configuring redhat_config options', () => {
+      expect(c.redhat_config).to.deep.equal(expectRedHatConfig);
     });
   });
 

--- a/test/fixtures/hadron-app/package.json
+++ b/test/fixtures/hadron-app/package.json
@@ -23,7 +23,22 @@
           "app_category_type": "public.app-category.productivity"
         },
         "linux": {
-          "icon": "resources/linux/Icon.png"
+          "icon": "resources/linux/Icon.png",
+          "debianConfig": {
+            "section": "Databases",
+            "depends": [
+              "python"
+            ],
+            "suggests": [
+              "libgnome-keyring0"
+            ]
+          },
+          "redhatConfig": {
+            "category": "Applications/Databases",
+            "requires": [
+              "libXScrnSaver(x86-64)"
+            ]
+          }
         }
       },
       "endpoint": "https://hadron-app.herokuapp.com",

--- a/test/fixtures/hadron-app/package.json
+++ b/test/fixtures/hadron-app/package.json
@@ -34,7 +34,9 @@
             ]
           },
           "redhat_config": {
-            "category": "Applications/Databases",
+            "categories": [
+              "Development"
+            ],
             "requires": [
               "libXScrnSaver(x86-64)"
             ]

--- a/test/fixtures/hadron-app/package.json
+++ b/test/fixtures/hadron-app/package.json
@@ -24,7 +24,7 @@
         },
         "linux": {
           "icon": "resources/linux/Icon.png",
-          "debianConfig": {
+          "debian_config": {
             "section": "Databases",
             "depends": [
               "python"
@@ -33,7 +33,7 @@
               "libgnome-keyring0"
             ]
           },
-          "redhatConfig": {
+          "redhat_config": {
             "category": "Applications/Databases",
             "requires": [
               "libXScrnSaver(x86-64)"


### PR DESCRIPTION
Adds a configuration feature that allows applications using `hadron-build` to set package metadata for Debian and Red Hat.

Also adds documentation and updates the fixture test for these new `build.linux.debian_config` and `build.linux.redhat_config` configuration keys. 

EDIT: Changed from `build.linux.debian` to `build.linux.debian_config` and also for redhat_config.