### PR TITLE
Drop check-python dependency

### DIFF
--- a/commands/verify.js
+++ b/commands/verify.js
@@ -2,7 +2,7 @@
 
 /**
  * Wouldn't it be great if you or a CI system were notified properly
- * that you aren't using the right version of node.js, npm or Python?
+ * that you aren't using the right version of node.js or npm?
  *
  * @see https://github.com/atom/atom/blob/master/script/utils/verify-requirements.js
  */
@@ -10,7 +10,6 @@ const Promise = require('bluebird');
 const semver = require('semver');
 const run = Promise.promisify(require('electron-installer-run'));
 const cli = require('mongodb-js-cli')('hadron-build:verify');
-const checkPython = Promise.promisify(require('check-python'));
 
 exports.command = 'verify [options]';
 exports.describe = 'Verify the current environment meets the app\'s requirements.';
@@ -27,15 +26,12 @@ exports.builder = {
 };
 
 exports.tasks = (argv) => {
-  return exports.checkPythonVersion()
-    .then(() => exports.checkNpmAndNodejsVersions(argv));
+  return exports.checkNpmAndNodejsVersions(argv);
 };
 
 exports.handler = (argv) => {
   exports.tasks(argv).catch((err) => cli.abortIfError(err));
 };
-
-exports.checkPythonVersion = () => checkPython();
 
 exports.checkNpmAndNodejsVersions = (opts) => {
   const expectNodeVersion = opts.nodejs_version;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "async": "^2.0.0-rc.3",
     "aws-sdk": "^2.3.2",
     "bluebird": "^3.3.4",
-    "check-python": "^1.0.0",
     "cli-table": "^0.3.1",
     "debug": "^2.2.0",
     "del": "^2.0.2",


### PR DESCRIPTION
We don’t change it from the default Travis images which are just Ubuntu precise/trusty/xenial.

Ubuntu itself is trying to move everything to Python3 so python won’t even be installed by default, sooner or later.
https://wiki.ubuntu.com/Python

i.e. IMHO It’s just not useful debugging information for us, anymore. And we’ll very likely get a node-security win out of it :)