### PR TITLE
Avoid ENAMETOOLONG on rhel

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -83,7 +83,8 @@ class Target {
       sign: null,
       afterExtract: [
         ffmpegAfterExtract
-      ]
+      ],
+      tmpdir: false
     };
 
     if (this.platform === 'win32') {


### PR DESCRIPTION
Trying [this suggestion from
electron-packager](https://github.com/electron-userland/electron-package
r/issues/396#issuecomment-264730685).

```
[2016/12/28 16:06:55.515]     at Error (native)
[2016/12/28 16:06:55.515]   errno: -36,
[2016/12/28 16:06:55.515]   code: 'ENAMETOOLONG',
[2016/12/28 16:06:55.515]   syscall: 'unlink',
[2016/12/28 16:06:55.515]   path:
'/data/mci/c5ff319993fa42af0c87ceed59d4feac/src/electron-packager/linux-
x64…
```