### PR TITLE
COMPASS-648 reorganize test folder structure. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ npm install --save-dev hadron-build;
 
 ### `hadron-build test`
 
+Tests are organized in test suites. Currently supported test suites are
+
+- `unit`: Fast unit tests of individual functions / methods
+- `enzyme`: React component tests using the [Enzyme](https://github.com/airbnb/enzyme) framework
+- `packages`: Tests specified in the `./src/internal-packages` folders (mostly unit and enzyme tests)
+- `main`: Electron-specific tests run in the main process
+- `renderer`: Electron-specific tests run in the renderer process
+- `functional`: Slow functional test using [Spectron](https://github.com/electron/spectron) (launches the application)
+
+With no additional arguments, all test suites are run in this order.
+
+A subset of test suites can be executed via command line flags.
+
+If you only want to run the unit and enzyme tests:
+```
+hadron-build test --unit --enzyme
+```
+
+
+
+Each test suite is executed in its own process.
+
 ### `hadron-build develop`
 
 ### `hadron-build clean`
@@ -328,7 +350,7 @@ Which assets are generated depends on the target platform.
 ## Todo
 
 - upload (github/s3) refactoring
-- `upload` writes to Atlas 
+- `upload` writes to Atlas
 - yargs -> commander
 - Docs
 - Changelog generator

--- a/README.md
+++ b/README.md
@@ -27,16 +27,13 @@ Tests are organized in test suites. Currently supported test suites are
 - `renderer`: Electron-specific tests run in the renderer process
 - `functional`: Slow functional test using [Spectron](https://github.com/electron/spectron) (launches the application)
 
-With no additional arguments, all test suites are run in this order.
+With no additional arguments, all test suites (except `packages`) are run in this order.
 
-A subset of test suites can be executed via command line flags.
-
-If you only want to run the unit and enzyme tests:
+A subset of test suites can be executed via command line flags. If you only want
+to run the unit and enzyme tests:
 ```
 hadron-build test --unit --enzyme
 ```
-
-
 
 Each test suite is executed in its own process.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "asar": "^0.13.0",
-    "async": "^2.0.0-rc.3",
+    "async": "^2.1.4",
     "aws-sdk": "^2.3.2",
     "bluebird": "^3.3.4",
     "check-python": "^1.0.0",
@@ -64,7 +64,7 @@
     "mocha": "^3.1.2",
     "mongodb-js-fmt": "^0.0.3",
     "mongodb-js-precommit": "^0.2.9",
-    "sinon": "^1.17.3",
+    "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {

--- a/test/fixtures/hadron-app/src/internal-packages/index.js
+++ b/test/fixtures/hadron-app/src/internal-packages/index.js
@@ -1,0 +1,1 @@
+// code would go here.

--- a/test/fixtures/hadron-app/test/enzyme/index.test.js
+++ b/test/fixtures/hadron-app/test/enzyme/index.test.js
@@ -1,0 +1,1 @@
+// tests would go here.

--- a/test/fixtures/hadron-app/test/functional/index.test.js
+++ b/test/fixtures/hadron-app/test/functional/index.test.js
@@ -1,0 +1,1 @@
+// tests would go here.

--- a/test/fixtures/hadron-app/test/main/index.test.js
+++ b/test/fixtures/hadron-app/test/main/index.test.js
@@ -1,0 +1,1 @@
+// tests would go here.

--- a/test/fixtures/hadron-app/test/renderer/index.test.js
+++ b/test/fixtures/hadron-app/test/renderer/index.test.js
@@ -1,0 +1,1 @@
+// tests would go here.

--- a/test/fixtures/hadron-app/test/unit/index.test.js
+++ b/test/fixtures/hadron-app/test/unit/index.test.js
@@ -1,0 +1,1 @@
+// tests would go here.


### PR DESCRIPTION
Introducing test suites:

- `unit`: Fast unit tests of individual functions / methods
- `enzyme`: React component tests using the [Enzyme](https://github.com/airbnb/enzyme) framework
- `packages`: Tests specified in the `./src/internal-packages` folders (mostly unit and enzyme tests)
- `main`: Electron-specific tests run in the main process
- `renderer`: Electron-specific tests run in the renderer process
- `functional`: Slow functional test using [Spectron](https://github.com/electron/spectron) (launches the application)

Test suites are run in their own process each, with the correct arguments. For example, renderer tests require the `--renderer` flag, packages tests require `--recursive`.
