### PR TITLE
Drop check-python to fix Windows dev install

### DIFF
--- a/commands/verify.js
+++ b/commands/verify.js
@@ -2,7 +2,7 @@
 
 /**
  * Wouldn't it be great if you or a CI system were notified properly
- * that you aren't using the right version of node.js, npm or Python?
+ * that you aren't using the right version of node.js or npm?
  *
  * @see https://github.com/atom/atom/blob/master/script/utils/verify-requirements.js
  */
@@ -10,7 +10,6 @@ const Promise = require('bluebird');
 const semver = require('semver');
 const run = Promise.promisify(require('electron-installer-run'));
 const cli = require('mongodb-js-cli')('hadron-build:verify');
-const checkPython = Promise.promisify(require('check-python'));
 
 exports.command = 'verify [options]';
 exports.describe = 'Verify the current environment meets the app\'s requirements.';
@@ -27,15 +26,12 @@ exports.builder = {
 };
 
 exports.tasks = (argv) => {
-  return exports.checkPythonVersion()
-    .then(() => exports.checkNpmAndNodejsVersions(argv));
+  return exports.checkNpmAndNodejsVersions(argv);
 };
 
 exports.handler = (argv) => {
   exports.tasks(argv).catch((err) => cli.abortIfError(err));
 };
-
-exports.checkPythonVersion = () => checkPython();
 
 exports.checkNpmAndNodejsVersions = (opts) => {
   const expectNodeVersion = opts.nodejs_version;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "async": "^2.1.4",
     "aws-sdk": "^2.3.2",
     "bluebird": "^3.3.4",
-    "check-python": "^1.0.0",
     "cli-table": "^0.3.1",
     "debug": "^2.2.0",
     "del": "^2.0.2",


### PR DESCRIPTION
This fixes installing Compass for development on Windows 10:

BEFORE

<img width="930" alt="drop check-python allows compass on windows to start" src="https://cloud.githubusercontent.com/assets/1217010/22918648/70ef27b8-f2df-11e6-84f4-bf2109d33bd8.png">


AFTER

<img width="1025" alt="yay" src="https://cloud.githubusercontent.com/assets/1217010/22918654/77c3bf68-f2df-11e6-92b4-afd3a57e0d6b.png">
