### PR TITLE
COMPASS-748: Fix Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "electron-installer-dmg": "^0.1.1",
     "electron-installer-redhat": "^0.3.0",
     "electron-osx-sign": "^0.4.1",
-    "electron-winstaller": "^2.3.3"
+    "electron-winstaller": "2.5.1"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
This pull request pins our `electron-winstaller` dependency at the `2.5.1` release from mid-December 2016 and is known good.  This fixes Compass' Windows builds (see [evergreen results](https://evergreen.mongodb.com/task/10gen_compass_master_windows_compile_cafb3d091be686d9f36bd84447bc2c88abebe866_17_03_01_16_47_13)).

On Jan 25th, [Squirrel.Windows added dll and node files to the list of artifacts `--releasify` attempts to codesign](https://github.com/Squirrel/Squirrel.Windows/commit/d37e20042ea04b132f05a80a6b186878ac26f375). On Jan. 26th, Compass Windows builds started failing for an unknown reason. I've back-tracked this to the `electron-winstaller` 2.5.2 release on the same day, which included [the `--releasify` changes from Squirrel.Windows](https://github.com/Squirrel/Squirrel.Windows/commit/d37e20042ea04b132f05a80a6b186878ac26f375).  `.dll` and `.node` files are not currently supported by the notary service. The `signtool.exe` added by BUILD-920 shows a generic error message instead of the error message returned by the notary service, which would have made this entire process much faster in its resolution.

Closes: BUILD-2885 COMPASS-748

cc @pzrq 