### PR TITLE
COMPASS-914: Style manager puts styles in head during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "got": "^6.3.0",
     "hadron-compile-cache": "^1.0.1",
     "hadron-module-cache": "^0.0.4",
+    "hadron-style-manager": "^0.1.0",
     "in-publish": "^2.0.0",
     "js-yaml": "^3.5.4",
     "less-cache": "^0.24.0",

--- a/test/fixtures/hadron-app/package.json
+++ b/test/fixtures/hadron-app/package.json
@@ -26,6 +26,13 @@
           "icon": "resources/linux/Icon.png"
         }
       },
+      "distributions": {
+        "compass-lite": {
+          "name": "Compass Lite",
+          "packages": [],
+          "styles": [ "index" ]
+        }
+      },
       "endpoint": "https://hadron-app.herokuapp.com",
       "protocols": [
         {

--- a/test/fixtures/hadron-app/src/app/index.html
+++ b/test/fixtures/hadron-app/src/app/index.html
@@ -1,0 +1,4 @@
+<html>
+  <head>
+  </head>
+</html>

--- a/test/release.test.js
+++ b/test/release.test.js
@@ -18,7 +18,7 @@ if (process.platform === 'win32') {
         if (_err) {
           return done(_err);
         }
-        target = getConfig({version: '1.2.0'});
+        target = getConfig({ version: '1.2.0' });
         commands.release.run(target, done);
       });
     });


### PR DESCRIPTION
Release command takes an optional distribution as an argument but defaults to `compass-lite` for backwards compatibility for the time being.

`hadron-build release compass-enterprise`.

The style manager will go through the configured packages and compile their index.less stylesheets and then inject them into the index.html. For backwards compatibility also reads from the packages configured styles names.