### PR TITLE
COMPASS-1019 - Truncate dmg names on macosx

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -370,22 +370,22 @@ class Target {
       this.packagerOptions['app-bundle-id'] += `.${this.channel}`;
     }
 
-    this.osx_dmg_label = this.osx_dmg_filename = `${this.truncatedProductName}.dmg`;
-    this.osx_zip_label = this.osx_zip_filename = `${this.truncatedProductName}.zip`;
+    this.osx_dmg_label = this.osx_dmg_filename = `${this.productName}.dmg`;
+    this.osx_zip_label = this.osx_zip_filename = `${this.productName}.zip`;
 
     this.assets = [
       {
         name: `${this.id}-${this.version}-${this.platform}-${this.arch}.dmg`,
-        path: this.dest(`${this.truncatedProductName}.dmg`)
+        path: this.dest(`${this.productName}.dmg`)
       },
       {
         name: `${this.id}-${this.version}-${this.platform}-${this.arch}.zip`,
-        path: this.dest(`${this.truncatedProductName}.zip`)
+        path: this.dest(`${this.productName}.zip`)
       }
     ];
 
     this.installerOptions = {
-      dmgPath: this.dest(`${this.truncatedProductName}.dmg`),
+      dmgPath: this.dest(`${this.productName}.dmg`),
       title: this.truncatedProductName, // actually names the dmg
       overwrite: true,
       out: this.out,

--- a/lib/target.js
+++ b/lib/target.js
@@ -346,6 +346,7 @@ class Target {
    * Apply macOS specific configuration.
    */
   configureForDarwin() {
+    this.truncatedProductName = this.productName.substring(0, 25);
     const platformSettings = _.get(this.pkg, 'config.hadron.build.darwin', {
       app_category_type: 'public.app-category.productivity',
       icon: `${this.id}.icns`
@@ -369,23 +370,23 @@ class Target {
       this.packagerOptions['app-bundle-id'] += `.${this.channel}`;
     }
 
-    this.osx_dmg_label = this.osx_dmg_filename = `${this.productName}.dmg`;
-    this.osx_zip_label = this.osx_zip_filename = `${this.productName}.zip`;
+    this.osx_dmg_label = this.osx_dmg_filename = `${this.truncatedProductName}.dmg`;
+    this.osx_zip_label = this.osx_zip_filename = `${this.truncatedProductName}.zip`;
 
     this.assets = [
       {
         name: `${this.id}-${this.version}-${this.platform}-${this.arch}.dmg`,
-        path: this.dest(`${this.productName}.dmg`)
+        path: this.dest(`${this.truncatedProductName}.dmg`)
       },
       {
         name: `${this.id}-${this.version}-${this.platform}-${this.arch}.zip`,
-        path: this.dest(`${this.productName}.zip`)
+        path: this.dest(`${this.truncatedProductName}.zip`)
       }
     ];
 
     this.installerOptions = {
-      dmgPath: this.dest(`${this.productName}.dmg`),
-      title: this.productName,
+      dmgPath: this.dest(`${this.truncatedProductName}.dmg`),
+      title: this.truncatedProductName, // actually names the dmg
       overwrite: true,
       out: this.out,
       icon: this.packagerOptions.icon,

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -32,7 +32,7 @@ describe('hadron-build::config', () => {
     });
 
     it('should not include channel in the product name on stable', () => {
-      expect(channels.stable.productName).to.equal('Compass Lite');
+      expect(channels.stable.productName).to.equal('MongoDB Compass Enterprise super long test name');
     });
 
     it('should not include channel in the slug on stable', () => {
@@ -41,8 +41,8 @@ describe('hadron-build::config', () => {
 
     describe('For releases *not* on the stable channel', () => {
       it('should add the channel as a suffix to the product name', () => {
-        expect(channels.beta.productName).to.equal('Compass Lite Beta');
-        expect(channels.custom.productName).to.equal('Compass Lite Custom');
+        expect(channels.beta.productName).to.equal('MongoDB Compass Enterprise super long test name Beta');
+        expect(channels.custom.productName).to.equal('MongoDB Compass Enterprise super long test name Custom');
       });
       it('should add the channel as a suffix to the slug', () => {
         expect(channels.beta.slug).to.equal('compass-lite-beta');
@@ -140,11 +140,11 @@ describe('hadron-build::config', () => {
     });
 
     it('should have the platform specific evergreen expansions', () => {
-      expect(res.windows_msi_filename).to.equal('Compass LiteSetup.msi');
-      expect(res.windows_setup_filename).to.equal('Compass LiteSetup.exe');
-      expect(res.windows_zip_filename).to.equal('Compass Lite-windows.zip');
-      expect(res.windows_nupkg_full_filename).to.equal('CompassLite-1.2.0-full.nupkg');
-      expect(res.windows_nupkg_full_label).to.equal('CompassLite-1.2.0-full.nupkg');
+      expect(res.windows_msi_filename).to.equal('MongoDB Compass Enterprise super long test nameSetup.msi');
+      expect(res.windows_setup_filename).to.equal('MongoDB Compass Enterprise super long test nameSetup.exe');
+      expect(res.windows_zip_filename).to.equal('MongoDB Compass Enterprise super long test name-windows.zip');
+      expect(res.windows_nupkg_full_filename).to.equal('MongoDBCompassEnterprisesuperlongtestname-1.2.0-full.nupkg');
+      expect(res.windows_nupkg_full_label).to.equal('MongoDBCompassEnterprisesuperlongtestname-1.2.0-full.nupkg');
     });
 
     it('should have the platform specific installer options', () => {
@@ -178,14 +178,14 @@ describe('hadron-build::config', () => {
 
       it('should append the channel name to the product name', () => {
         let versionString = custom.packagerOptions['version-string'];
-        expect(versionString.ProductName).to.equal('Compass Lite Custom');
+        expect(versionString.ProductName).to.equal('MongoDB Compass Enterprise super long test name Custom');
       });
 
       it('should include the channel name in asset filenames', () => {
-        expect(custom.windows_msi_filename).to.equal('Compass Lite CustomSetup.msi');
-        expect(custom.windows_setup_filename).to.equal('Compass Lite CustomSetup.exe');
-        expect(custom.windows_zip_filename).to.equal('Compass Lite Custom-windows.zip');
-        expect(custom.windows_nupkg_full_filename).to.equal('CompassLiteCustom-1.2.0-custom5-full.nupkg');
+        expect(custom.windows_msi_filename).to.equal('MongoDB Compass Enterprise super long test name CustomSetup.msi');
+        expect(custom.windows_setup_filename).to.equal('MongoDB Compass Enterprise super long test name CustomSetup.exe');
+        expect(custom.windows_zip_filename).to.equal('MongoDB Compass Enterprise super long test name Custom-windows.zip');
+        expect(custom.windows_nupkg_full_filename).to.equal('MongoDBCompassEnterprisesuperlongtestnameCustom-1.2.0-custom5-full.nupkg');
       });
     });
   });

--- a/test/fixtures/hadron-app/package.json
+++ b/test/fixtures/hadron-app/package.json
@@ -30,7 +30,7 @@
         "package-prefix": "compass",
         "compass-lite": {
           "name": "compass-lite",
-          "productName": "Compass Lite",
+          "productName": "MongoDB Compass Enterprise super long test name",
           "packages": [],
           "styles": [ "index" ]
         }


### PR DESCRIPTION
Anything longer than 27 characters will trigger an error in appdmg.