### PR TITLE
COMPASS-1044 - Make libsecret a dependency for debian

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -532,7 +532,7 @@ class Target {
         version: debianVersion,
         bin: this.productName,
         section: debianSection,
-        suggests: [
+        depends: [
           'libsecret'
         ]
       },


### PR DESCRIPTION
@durran or @imlucas would you mind explaining why we need to do this? Ticket seems straightforward enough.