### PR TITLE
COMPASS-704 Remove packages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ Tests are organized in test suites. Currently supported test suites are
 
 - `unit`: Fast unit tests of individual functions / methods
 - `enzyme`: React component tests using the [Enzyme](https://github.com/airbnb/enzyme) framework
-- `packages`: Tests specified in the `./src/internal-packages` folders (mostly unit and enzyme tests)
 - `main`: Electron-specific tests run in the main process
 - `renderer`: Electron-specific tests run in the renderer process
 - `functional`: Slow functional test using [Spectron](https://github.com/electron/spectron) (launches the application)
 
-With no additional arguments, all test suites (except `packages`) are run in this order.
+With no additional arguments, all test suites are run in this order.
 
 A subset of test suites can be executed via command line flags. If you only want
 to run the unit and enzyme tests:

--- a/commands/test.js
+++ b/commands/test.js
@@ -12,7 +12,7 @@ const async = require('async');
 const fs = require('fs-extra');
 
 const ELECTRON_MOCHA = which.sync('electron-mocha');
-const TEST_SUITES = ['unit', 'enzyme', 'packages', 'main', 'renderer', 'functional'];
+const TEST_SUITES = ['unit', 'enzyme', 'main', 'renderer', 'functional'];
 
 // const debug = require('debug')('hadron-build:test');
 
@@ -27,10 +27,6 @@ exports.builder = {
   },
   enzyme: {
     description: 'Run enzyme tests for React components.',
-    default: false
-  },
-  packages: {
-    description: 'Run the individual internal-packages tests',
     default: false
   },
   main: {
@@ -99,7 +95,7 @@ exports.getSpawnJobs = (argv) => {
   const spawnJobs = {};
   _.each(TEST_SUITES, (suite) => {
     // suite path and special handling of packages
-    const suitePath = suite === 'packages' ? './src/internal-packages' : `./test/${suite}`;
+    const suitePath = `./test/${suite}`;
     const mochaArgs = exports.getMochaArgs(argv);
     // add any extra arguments for suites, like e.g. --renderer
     if (_.get(extraSuiteArgs, suite)) {
@@ -133,12 +129,9 @@ exports.handler = (argv) => {
     process.env.EVENT_NOKQUEUE = '1';
   }
 
-  // if no individual suites are selected, run all of them except `packages`
+  // if no individual suites are selected, run all of them
   if (!_.some(_.map(TEST_SUITES, (suite) => argv[suite]))) {
     _.each(TEST_SUITES, (suite) => {
-      if (suite === 'packages') {
-        return;
-      }
       argv[suite] = true;
     });
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,6 @@ describe('hadron-build', () => {
         expect(commands.test.getSpawnJobs(argv)).to.deep.equal({
           unit: ['--sort', './test/unit'],
           enzyme: ['--sort', './test/enzyme'],
-          packages: ['--sort', '--recursive', './src/internal-packages'],
           main: ['--sort', './test/main'],
           renderer: ['--sort', '--renderer', './test/renderer'],
           functional: ['--sort', './test/functional']

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -61,7 +61,6 @@ describe('hadron-build', () => {
       help: false,
       unit: false,
       enzyme: false,
-      packages: false,
       main: false,
       renderer: false,
       functional: false,
@@ -86,7 +85,6 @@ describe('hadron-build', () => {
           enzyme: true,
           main: true,
           renderer: true,
-          packages: true,
           functional: true
         }, DEFAULT_ARGS);
         expect(commands.test.getSpawnJobs(argv)).to.deep.equal({


### PR DESCRIPTION
It never worked properly, workaround in Compass is to put tests into the top level tests folder, or better yet to convert the plugin to an external plugin.