### PR TITLE
COMPASS-4127: Rollback electron-winstaller to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1171,6 +1171,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "optional": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -1435,6 +1445,12 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "optional": true
+    },
     "builder-util": {
       "version": "22.3.2",
       "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.3.2.tgz",
@@ -1667,6 +1683,15 @@
         "assertion-error": "^1.0.1",
         "deep-eql": "^0.1.3",
         "type-detect": "^1.0.0"
+      }
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "optional": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
       }
     },
     "chalk": {
@@ -2352,6 +2377,32 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
+      "integrity": "sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==",
+      "optional": true,
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "optional": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
       }
     },
     "deep-eql": {
@@ -3953,51 +4004,82 @@
       }
     },
     "electron-winstaller": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-4.0.0.tgz",
-      "integrity": "sha512-Rq5YUQ/zBiGiDW3ezVaRigF3QbohVjDtfcpZpzmhJxX/1jndc96OQJw2x1HulHmhPV7n9R4WEsMkzkHObufU9g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-2.5.1.tgz",
+      "integrity": "sha1-p1n7gn2B2w9GV8P+o6c6plsWmbY=",
       "optional": true,
       "requires": {
-        "asar": "^2.0.1",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
+        "asar": "^0.11.0",
+        "bluebird": "^3.3.4",
+        "debug": "^2.2.0",
+        "fs-extra": "^0.26.7",
         "lodash.template": "^4.2.2",
-        "temp": "^0.9.0"
+        "temp": "^0.8.3"
       },
       "dependencies": {
         "asar": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/asar/-/asar-2.0.1.tgz",
-          "integrity": "sha512-Vo9yTuUtyFahkVMFaI6uMuX6N7k5DWa6a/8+7ov0/f8Lq9TVR0tUjzSzxQSxT1Y+RJIZgnP7BVb6Uhi+9cjxqA==",
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/asar/-/asar-0.11.0.tgz",
+          "integrity": "sha1-uSbnksMV+MBIxDNx4yWwnJenZGQ=",
           "optional": true,
           "requires": {
-            "chromium-pickle-js": "^0.2.0",
-            "commander": "^2.20.0",
-            "cuint": "^0.2.2",
-            "glob": "^7.1.3",
-            "minimatch": "^3.0.4",
-            "mkdirp": "^0.5.1",
-            "tmp-promise": "^1.0.5"
+            "chromium-pickle-js": "^0.1.0",
+            "commander": "^2.9.0",
+            "cuint": "^0.2.1",
+            "glob": "^6.0.4",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "mksnapshot": "^0.3.0"
           }
         },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "optional": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
+        "chromium-pickle-js": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
+          "integrity": "sha1-HUixB9ghJqLz4hHC6iX4A7pVGyE=",
+          "optional": true
         },
         "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
           "optional": true,
           "requires": {
             "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.9"
           }
         }
       }
@@ -7885,6 +7967,56 @@
         "minimist": "0.0.8"
       }
     },
+    "mkpath": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
+      "optional": true
+    },
+    "mksnapshot": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.5.tgz",
+      "integrity": "sha512-PSBoZaj9h9myC3uRRW62RxmX8mrN3XbOkMEyURUD7v5CeJgtYTar50XU738t7Q0LtG1pBPtp5n5QwDGggRnEvw==",
+      "optional": true,
+      "requires": {
+        "decompress-zip": "0.3.x",
+        "fs-extra": "0.26.7",
+        "request": "2.x"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.26.7",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+          "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.9"
+          }
+        }
+      }
+    },
     "mocha": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
@@ -9367,6 +9499,12 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "optional": true
     },
     "qs": {
       "version": "6.5.2",
@@ -10952,9 +11090,9 @@
       }
     },
     "temp": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
-      "integrity": "sha512-WMuOgiua1xb5R56lE0eH6ivpVmg/lq2OHm4+LtT/xtEtPQ+sz6N3bBM6WZ5FvO1lO4IKIOb43qnhoc4qxP5OeA==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
       "optional": true,
       "requires": {
         "rimraf": "~2.6.2"
@@ -11104,6 +11242,26 @@
         }
       }
     },
+    "touch": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "optional": true,
+      "requires": {
+        "nopt": "~1.0.10"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "optional": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -11169,6 +11327,12 @@
           }
         }
       }
+    },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "optional": true
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,13 +68,13 @@
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {
+    "@mongodb-js/electron-wix-msi": "^2.1.20",
     "electron-installer-codesign": "^0.3.0",
     "electron-installer-debian": "^2.0.1",
     "electron-installer-dmg": "^3.0.0",
     "electron-installer-redhat": "^2.0.0",
     "electron-osx-sign": "^0.4.1",
-    "electron-winstaller": "4.0.0",
-    "@mongodb-js/electron-wix-msi": "^2.1.20"
+    "electron-winstaller": "^2.5.1"
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Todo

- [x] [BUILD-2932](https://jira.mongodb.org/browse/BUILD-2932): notary service dll support

## Description

Rollback `electron-winstaller` to `2.5.1` for now. Don't upgrade until [BUILD-2932](https://jira.mongodb.org/browse/BUILD-2932) is done.

* Fixes COMPASS-4127 
* Answers BUILD-10250

## Notes

[Evergreen windows builds](https://evergreen.mongodb.com/task/10gen_compass_master_windows_package_and_publish_compass_3d7b0895c3d7ed4aada6f997286a8a57d7f835b5_20_01_31_17_33_22) started failing with the electron 6 update:

```
[2020/01/31 12:47:29.021] ×  Error: Error: Failed with exit code: 4294967295
--
[2020/01/31 12:47:29.021] Output:
[2020/01/31 12:47:29.021] System.AggregateException: One or more errors occurred. ---> System.Exception: Failed to sign, command invoked was: '.\signtool.exe sign yes C:\Users\mci-exec\AppData\Local\SquirrelTemp\tempa\lib\net45\ffmpeg.dll'
[2020/01/31 12:47:29.021]    at Squirrel.Update.Program.<signPEFile>d__17.MoveNext()
```

Normally, `Failed with exit code: 4294967295` means [the signtool.exe notary service client](https://jira.mongodb.org/browse/BUILD-920) is getting a 500 service error due to an outage.

However, all other OS were signing with no issues  [see BUILD-10250](https://jira.mongodb.org/browse/BUILD-10250).

```
cd /cygdrive/z/data/mci/src/dist/MongoDBCompassDev-win32-x64;

$ ../../signtool.exe sign yes ffmpeg.dll
2020/02/03 16:34:55 Signing service didn't return a permalink

$ ../../signtool.exe sign yes libEGL.dll
2020/02/03 16:35:14 Signing service didn't return a permalink

$ ../../signtool.exe sign yes MongoDBCompassDev.exe
Worked
$ ../../signtool.exe sign yes Squirrel.exe
Worked
```

So, it can't be a service issue and must be something related to the changes to `hadron-build` for COMPASS-3933 electron 6 support.

Only a handful of commits and [e3ff85c9303bc43e56976226d10d6b9897324b66](https://github.com/mongodb-js/hadron-build/commit/e3ff85c9303bc43e56976226d10d6b9897324b66)
`electron-winstaller` was upgraded from `2.5.1` to `4.0.0`. This changed the effective version of the [Squirrel.Windows](https://github.com/Squirrel/Squirrel.Windows) framework electron uses for win32 auto-update:

* `electron-winstaller@2.5.1.` :arrow_right:  [squirrel.windows@1.5.1](https://github.com/Squirrel/Squirrel.Windows/releases/tag/1.5.1)
* `electron-winstaller@>=3.0.0` :arrow_right: [squirrel.windows@1.9.1](https://github.com/Squirrel/Squirrel.Windows/releases/tag/1.9.1)

In `electron-winstaller@2.5.2` :arrow_right: [squirrel.windows@1.5.2](https://github.com/Squirrel/Squirrel.Windows/releases/tag/1.5.2):

> ### Releasify now disallows non-Semver versions
>
> While using non-Semver versions in your NuGet package was always incorrect and resulted in undefined behavior, due to #868, these are now a full non-starter. We now require packages to have Semver-compatible versions names. Note that this doesn't affect your EXE versions, which can still use all four Win32 version numbers.
>
> ### Bug Fixes
>
> - Allow uppercase characters in SemVer versions (#924, thanks)
> - Sign DLL and .node files during Releasify
> - Ensure that Stub Executables pass along their parameters to the target

And now the facepalm moment; [BUILD-2932](https://jira.mongodb.org/browse/BUILD-2932) (created in 2017) as the notary service doesn't support dll signing the way we need it to.