### PR TITLE
COMPASS-4077 - Allow loading Apple notarization credentials from file

### DIFF
--- a/lib/target.js
+++ b/lib/target.js
@@ -529,8 +529,20 @@ class Target {
               if (_err) {
                 return reject(_err);
               }
-              const appleUsername = process.env.APPLE_USERNAME;
-              const applePassword = process.env.APPLE_PASSWORD;
+              let appleUsername = process.env.APPLE_USERNAME;
+              let applePassword = process.env.APPLE_PASSWORD;
+              const appleCredentialsFile = process.env.APPLE_CREDENTIALS;
+              if ((!appleUsername || !applePassword) && appleCredentialsFile) {
+                try {
+                  /* eslint no-sync: 0 */
+                  const credentials = JSON.parse(fs.readFileSync(appleCredentialsFile, 'utf8'));
+                  appleUsername = credentials.appleUsername;
+                  applePassword = credentials.applePassword;
+                } catch (credentialsErr) {
+                  return reject(credentialsErr);
+                }
+              }
+
               if (appleUsername && applePassword) {
                 notarize({
                   appBundleId: this.bundleId,

--- a/lib/target.js
+++ b/lib/target.js
@@ -531,7 +531,7 @@ class Target {
               }
               let appleUsername = process.env.APPLE_USERNAME;
               let applePassword = process.env.APPLE_PASSWORD;
-              const appleCredentialsFile = process.env.APPLE_CREDENTIALS;
+              const appleCredentialsFile = process.env.APPLE_CREDENTIALS_FILE;
               if ((!appleUsername || !applePassword) && appleCredentialsFile) {
                 try {
                   /* eslint no-sync: 0 */


### PR DESCRIPTION
This way it’s easier to keep them out of the debug log in CI.