### PR TITLE
Keep scripts so that hooks can correctly run when packaging

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -308,7 +308,6 @@ const writeVersionFile = (CONFIG, done) => {
 const transformPackageJson = (CONFIG, done) => {
   const PACKAGE_JSON_DEST = path.join(CONFIG.resources, 'app', 'package.json');
   const packageKeysToRemove = [
-    'scripts',
     'devDependencies',
     'dependency-check',
     'repository',


### PR DESCRIPTION
Electron apps might depend on npm hooks to e.g., rebuild their native modules on postinstall to match electron version. As the plugin installs dependencies from scratch during packaging (not just copying them over from source), scripts should be preserved so hooks can run properly