### PR TITLE
feat: Allow to override asar options during the build

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -468,10 +468,10 @@ const createApplicationAsar = (CONFIG, done) => {
      *  ordering: path.join(process.cwd(),
      *   'resources', 'asar-ordering-hint.txt'),
      */
-    unpack: '{' + [
-      '*.node',
-      '**/vendor/**'
-    ].join(',') + '}'
+    ...CONFIG.asar,
+    unpack: `{${['*.node', '**/vendor/**']
+      .concat(CONFIG.asar.unpack)
+      .join(',')}}`
   };
 
   var src = path.join(CONFIG.resources, 'app');

--- a/lib/target.js
+++ b/lib/target.js
@@ -133,6 +133,8 @@ class Target {
     this.semver = new semver.SemVer(this.version);
     this.channel = 'stable';
 
+    this.asar = { unpack: [], ...pkg.config.hadron.asar };
+
     // extract channel from version string, e.g. `beta` for `1.3.5-beta.1`
     const mtch = this.version.match(/-([a-z]+)(\.\d+)?$/);
     if (mtch) {


### PR DESCRIPTION
We would need to unpack new compass shell runtime with all its dependencies for it to work correctly, for that reason this PR adds an ability to extend/override asar create options using hadron config